### PR TITLE
Fix sql generation and header buttons

### DIFF
--- a/src/components/ModernApp.js
+++ b/src/components/ModernApp.js
@@ -8,7 +8,7 @@ import SQLResult from './SQLResult';
 import LoadingSpinner from './LoadingSpinner';
 import { Toaster, toast } from 'react-hot-toast';
 import SQLGenerator from '../utils/sqlGenerators';
-import { FaDatabase, FaCog, FaPlay, FaHistory } from 'react-icons/fa';
+import { FaDatabase, FaCog, FaPlay, FaHistory, FaShare } from 'react-icons/fa';
 
 const ModernApp = () => {
   const { isDarkMode } = useTheme();
@@ -123,6 +123,10 @@ const ModernApp = () => {
     setTableName(value);
   };
 
+  const handleSectionChange = (section) => {
+    setActiveSection(section);
+  };
+
   if (!isLoggedIn) {
     return <LoginScreen onLogin={handleLogin} />;
   }
@@ -131,7 +135,7 @@ const ModernApp = () => {
     <div className={`app ${isDarkMode ? 'dark-mode' : ''}`}>
       <Toaster position="top-right" />
       
-      <Navigation onLogout={handleLogout} />
+      <Navigation onLogout={handleLogout} onSectionChange={handleSectionChange} />
       
       <div className="container-fluid mt-4">
         <div className="row">
@@ -313,6 +317,73 @@ const ModernApp = () => {
                           </table>
                         </div>
                       )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {activeSection === 'share' && (
+              <div className="row">
+                <div className="col-12">
+                  <div className="card">
+                    <div className="card-header">
+                      <h6 className="mb-0">
+                        <FaShare className="me-2" />
+                        Share Configuration
+                      </h6>
+                    </div>
+                    <div className="card-body">
+                      <div className="row">
+                        <div className="col-md-6">
+                          <h6>Export Configuration</h6>
+                          <p className="text-muted">Share your current table configuration with others.</p>
+                          <button 
+                            className="btn btn-primary"
+                            onClick={() => {
+                              const config = {
+                                tableName,
+                                columns,
+                                databaseType,
+                                rowCount
+                              };
+                              const configString = JSON.stringify(config, null, 2);
+                              navigator.clipboard.writeText(configString);
+                              toast.success('Configuration copied to clipboard!');
+                            }}
+                          >
+                            Copy Configuration
+                          </button>
+                        </div>
+                        <div className="col-md-6">
+                          <h6>Import Configuration</h6>
+                          <p className="text-muted">Paste a configuration to load it.</p>
+                          <textarea
+                            className="form-control mb-2"
+                            rows="4"
+                            placeholder="Paste configuration JSON here..."
+                            id="importConfig"
+                          />
+                          <button 
+                            className="btn btn-secondary"
+                            onClick={() => {
+                              const configText = document.getElementById('importConfig').value;
+                              try {
+                                const config = JSON.parse(configText);
+                                setTableName(config.tableName || 'table1');
+                                setColumns(config.columns || []);
+                                setDatabaseType(config.databaseType || 'mysql');
+                                setRowCount(config.rowCount || 25);
+                                toast.success('Configuration imported successfully!');
+                              } catch (error) {
+                                toast.error('Invalid configuration format');
+                              }
+                            }}
+                          >
+                            Import Configuration
+                          </button>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -2,16 +2,23 @@ import React, { useState } from 'react';
 import { useTheme } from '../contexts/ThemeContext';
 import { FaDatabase, FaCog, FaHistory, FaShare, FaMoon, FaSun, FaBars, FaTimes } from 'react-icons/fa';
 
-const Navigation = () => {
+const Navigation = ({ onSectionChange }) => {
   const { isDarkMode, toggleTheme } = useTheme();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const navItems = [
-    { name: 'Generator', icon: <FaDatabase />, href: '#generator' },
-    { name: 'Templates', icon: <FaCog />, href: '#templates' },
-    { name: 'History', icon: <FaHistory />, href: '#history' },
-    { name: 'Share', icon: <FaShare />, href: '#share' }
+    { name: 'Generator', icon: <FaDatabase />, href: '#generator', section: 'generator' },
+    { name: 'Templates', icon: <FaCog />, href: '#templates', section: 'templates' },
+    { name: 'History', icon: <FaHistory />, href: '#history', section: 'history' },
+    { name: 'Share', icon: <FaShare />, href: '#share', section: 'share' }
   ];
+
+  const handleNavClick = (e, section) => {
+    e.preventDefault();
+    if (onSectionChange) {
+      onSectionChange(section);
+    }
+  };
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
@@ -39,7 +46,11 @@ const Navigation = () => {
           <ul className="navbar-nav me-auto mb-2 mb-lg-0">
             {navItems.map((item, index) => (
               <li key={index} className="nav-item">
-                <a className="nav-link d-flex align-items-center" href={item.href}>
+                <a 
+                  className="nav-link d-flex align-items-center" 
+                  href={item.href}
+                  onClick={(e) => handleNavClick(e, item.section)}
+                >
                   {item.icon}
                   <span className="ms-1">{item.name}</span>
                 </a>

--- a/src/utils/dataGenerators.js
+++ b/src/utils/dataGenerators.js
@@ -53,7 +53,7 @@ export class EnhancedDataGenerator {
   }
 
   static phone() {
-    return "'" + faker.phone.number('###-###-####') + "'";
+    return "'" + faker.phone.phoneNumber('###-###-####') + "'";
   }
 
   static ssn() {
@@ -81,11 +81,11 @@ export class EnhancedDataGenerator {
   }
 
   static company() {
-    return "'" + faker.company.name() + "'";
+    return "'" + faker.company.companyName() + "'";
   }
 
   static jobTitle() {
-    return "'" + faker.person.jobTitle() + "'";
+    return "'" + faker.name.jobTitle() + "'";
   }
 
   static department() {
@@ -109,7 +109,7 @@ export class EnhancedDataGenerator {
   }
 
   static uuid() {
-    return "'" + faker.string.uuid() + "'";
+    return "'" + faker.datatype.uuid() + "'";
   }
 
   static macAddress() {
@@ -125,31 +125,31 @@ export class EnhancedDataGenerator {
   }
 
   static streetAddress() {
-    return "'" + faker.location.streetAddress() + "'";
+    return "'" + faker.address.streetAddress() + "'";
   }
 
   static city() {
-    return "'" + faker.location.city() + "'";
+    return "'" + faker.address.city() + "'";
   }
 
   static state() {
-    return "'" + faker.location.state() + "'";
+    return "'" + faker.address.state() + "'";
   }
 
   static zipCode() {
-    return "'" + faker.location.zipCode() + "'";
+    return "'" + faker.address.zipCode() + "'";
   }
 
   static country() {
-    return "'" + faker.location.country() + "'";
+    return "'" + faker.address.country() + "'";
   }
 
   static latitude() {
-    return faker.location.latitude();
+    return faker.address.latitude();
   }
 
   static longitude() {
-    return faker.location.longitude();
+    return faker.address.longitude();
   }
 
   static coordinates() {
@@ -158,19 +158,19 @@ export class EnhancedDataGenerator {
 
   // Legacy methods for backward compatibility
   static getName(radio) {
-    return "'" + faker.person.firstName() + "'";
+    return "'" + faker.name.firstName() + "'";
   }
 
   static getLastName(radio) {
-    return "'" + faker.person.lastName() + "'";
+    return "'" + faker.name.lastName() + "'";
   }
 
   static getCity(radio) {
-    return "'" + faker.location.city() + "'";
+    return "'" + faker.address.city() + "'";
   }
 
   static getCountry(radio) {
-    return "'" + faker.location.country() + "'";
+    return "'" + faker.address.country() + "'";
   }
 
   static getSample(radio) {

--- a/src/utils/sqlGenerators.js
+++ b/src/utils/sqlGenerators.js
@@ -85,139 +85,137 @@ class BaseGenerator {
   }
 
   generateDataValue(column, rowIndex) {
-    const generator = new EnhancedDataGenerator();
-    
     switch (column.selectedOption) {
       case 'Bit':
         return Math.random() > 0.5 ? 1 : 0;
       
       case 'Tinyint':
         if (column.radio === 'PK') return rowIndex;
-        return generator.numbers_random(0, 255);
+        return EnhancedDataGenerator.numbers_random(0, 255);
       
       case 'Int':
         if (column.intRangeState) {
-          return generator.numbers_random(column.min, column.max);
+          return EnhancedDataGenerator.numbers_random(column.min, column.max);
         }
         if (column.radio === 'PK') return rowIndex;
-        return generator.numbers();
+        return EnhancedDataGenerator.numbers();
       
       case 'Bigint':
         if (column.radio === 'PK') return rowIndex;
-        return generator.numbers() + '' + generator.numbers() + '' + generator.numbers();
+        return EnhancedDataGenerator.numbers() + '' + EnhancedDataGenerator.numbers() + '' + EnhancedDataGenerator.numbers();
       
       case 'Float':
-        return generator.numbers_float();
+        return EnhancedDataGenerator.numbers_float();
       
       case 'Decimal':
       case 'Money':
       case 'Price':
-        return generator.decimal();
+        return EnhancedDataGenerator.decimal();
       
       case 'Date':
-        return generator.date();
+        return EnhancedDataGenerator.date();
       
       case 'Time':
-        return generator.time();
+        return EnhancedDataGenerator.time();
       
       case 'DateTime':
-        return generator.dateTime();
+        return EnhancedDataGenerator.dateTime();
       
       case 'Text':
       case 'ProductDescription':
-        return generator.text();
+        return EnhancedDataGenerator.text();
       
       case 'Email':
-        return generator.email();
+        return EnhancedDataGenerator.email();
       
       case 'Phone':
-        return generator.phone();
+        return EnhancedDataGenerator.phone();
       
       case 'SSN':
-        return generator.ssn();
+        return EnhancedDataGenerator.ssn();
       
       case 'CreditCard':
-        return generator.creditCard();
+        return EnhancedDataGenerator.creditCard();
       
       case 'IPAddress':
-        return generator.ipAddress();
+        return EnhancedDataGenerator.ipAddress();
       
       case 'URL':
-        return generator.url();
+        return EnhancedDataGenerator.url();
       
       case 'Username':
-        return generator.username();
+        return EnhancedDataGenerator.username();
       
       case 'Password':
-        return generator.password();
+        return EnhancedDataGenerator.password();
       
       case 'Company':
-        return generator.company();
+        return EnhancedDataGenerator.company();
       
       case 'JobTitle':
-        return generator.jobTitle();
+        return EnhancedDataGenerator.jobTitle();
       
       case 'Department':
-        return generator.department();
+        return EnhancedDataGenerator.department();
       
       case 'ProductName':
-        return generator.productName();
+        return EnhancedDataGenerator.productName();
       
       case 'ISBN':
-        return generator.isbn();
+        return EnhancedDataGenerator.isbn();
       
       case 'UUID':
-        return generator.uuid();
+        return EnhancedDataGenerator.uuid();
       
       case 'MacAddress':
-        return generator.macAddress();
+        return EnhancedDataGenerator.macAddress();
       
       case 'Color':
-        return generator.color();
+        return EnhancedDataGenerator.color();
       
       case 'Domain':
-        return generator.domain();
+        return EnhancedDataGenerator.domain();
       
       case 'StreetAddress':
-        return generator.streetAddress();
+        return EnhancedDataGenerator.streetAddress();
       
       case 'City':
-        return generator.city();
+        return EnhancedDataGenerator.city();
       
       case 'State':
-        return generator.state();
+        return EnhancedDataGenerator.state();
       
       case 'ZipCode':
-        return generator.zipCode();
+        return EnhancedDataGenerator.zipCode();
       
       case 'Country':
-        return generator.country();
+        return EnhancedDataGenerator.country();
       
       case 'Coordinates':
-        return generator.coordinates();
+        return EnhancedDataGenerator.coordinates();
       
       case 'Nvarchar':
         switch (column.selectedDataOption) {
           case 'Names':
-            return generator.getName();
+            return EnhancedDataGenerator.getName();
           case 'Last Name':
-            return generator.getLastName();
+            return EnhancedDataGenerator.getLastName();
           case 'Cities':
-            return generator.getCity();
+            return EnhancedDataGenerator.getCity();
           case 'Countries':
-            return generator.getCountry();
+            return EnhancedDataGenerator.getCountry();
           case 'Sample':
-            return generator.getSample();
+            return EnhancedDataGenerator.getSample();
           case 'Custom list':
             return this.getCustomListValue(column.customList, rowIndex);
           case 'Custom list nvarchar':
             return `'${this.getCustomListValue(column.customList, rowIndex)}'`;
           default:
-            return generator.getName();
+            return EnhancedDataGenerator.getName();
         }
       
       default:
-        return generator.getName();
+        return EnhancedDataGenerator.getName();
     }
   }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes SQL generation error and enables header navigation, including Faker API compatibility and a new Share section.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The SQL generation error (`TypeError: n.getName is not a function`) was due to `EnhancedDataGenerator`'s static methods being called on an instance; this is corrected to direct class calls. Header navigation buttons now correctly switch sections via a new `onSectionChange` prop and state management in `ModernApp.js`. This also includes adding the previously non-functional 'Share' section with import/export capabilities. Lastly, Faker API calls were updated for compatibility with faker v5.5.3.

---
<a href="https://cursor.com/background-agent?bcId=bc-28152e23-8c8e-468f-8584-3b4af1398090">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28152e23-8c8e-468f-8584-3b4af1398090">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>